### PR TITLE
[DM-35644] Restore missing rST settings.

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -1,3 +1,7 @@
+:tocdepth: 1
+
+.. sectnum::
+
 Abstract
 ========
 


### PR DESCRIPTION
Limit the table of contents depth and add section numbering.