### PR TITLE
DM-36404: Add future scopes, clarify more discussion

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -54,6 +54,18 @@ Current scopes
 
 The following scopes are currently in use:
 
+``admin:provision``
+    Grants access to the API used to provision home directories and other resources for new users.
+    This allows running a privileged container with arbitrary user data (although the container itself is not under the control of the API client).
+    Provisioning is currently provided by the moneypenny_ service.
+
+    This scope is granted to deployment administrators and to the JupyterHub service so that it can provision new users on initial lab spawn.
+
+    If SQR-066_ is implemented, this scope will be retired and replaced with an ``admin:notebook`` scope with slightly different capabilities.
+
+.. _moneypenny: https://github.com/lsst-sqre/moneypenny
+.. _SQR-066: https://sqr-066.lsst.io/
+
 ``admin:token``
     Grants token administrator powers.
     Users authenticated with a token with this scope can view, create, modify, and delete tokens for any user.
@@ -68,20 +80,12 @@ The following scopes are currently in use:
 .. _noteburst: https://noteburst.lsst.io/
 .. _times-square: https://github.com/lsst-sqre/times-square
 
-``admin:provision``
-    Grants access to the API used to provision home directories and other resources for new users.
-    This allows running a privileged container with arbitrary user data (although the container itself is not under the control of the API client).
-    Provisioning is currently provided by the moneypenny_ service.
-
-    This scope is granted to deployment administrators and to the nublado2 service so that it can provision new users on initial lab spawn.
-
-.. _moneypenny: https://github.com/lsst-sqre/moneypenny
-
 ``exec:admin``
     Grants access to various privileged services that should only be used by deployment administrators.
     This is a bit of a grab bag for administrative access by humans to services that don't need to allow access from other services.
 
     Currently, this grants access to the admin APIs of cachemachine_, mobu_, noteburst_, sherlock_, and times-square_, and to the admin routes for the Portal Aspect.
+    We may replace this scope with one or more scopes starting with ``admin:`` to keep all admin scopes similarly named.
 
 .. _cachemachine: https://github.com/lsst-sqre/cachemachine
 .. _sherlock: https://github.com/lsst-sqre/sherlock
@@ -94,17 +98,20 @@ The following scopes are currently in use:
 
 ``exec:portal``
     Allows the user to perform operations in the Portal Aspect.
-    Due to the underlying queries the Portal performs, the user will also need ``read:image`` and ``read:tap`` scopes.
+
+    This grants access only to the Portal itself, not to any of the underlying services that the Portal may query on the user's behalf.
+    To fully use all Portal functionality, the user will also need ``read:image`` and ``read:tap`` scopes, and possibly others.
+    The Portal requests those scopes if they're available, but does not require them to access the Portal itself.
 
 ``read:alertdb``
     Grants access to receive alert packets and schemas from the alert archive database.
 
 ``read:image``
     Grants access to retrieve images accessible via the Science Platform.
-    Currently, this controls access to the HiPS (see DMTN-230_), SODA image cutout (see DMTN-208_), and DataLink (as implemented by datalinker_) services.
+    Currently, this controls access to HiPS (see DMTN-230_), SODA image cutout (see DMTN-208_), and the DataLink ``/api/datalinker/links`` route (as implemented by datalinker_).
 
-    At present, there is a single scope for access to all images.
-    In the future, this may be broken into separate scopes for data releases or types of images.
+    Following the guidelines in :ref:`purpose`, there is a single scope for image access that controls whether the user can download images at all.
+    Access to specific images, such as access controls by data release, will be handled via groups.
 
 .. _DMTN-230: https://dmtn-230.lsst.io/
 .. _DMTN-208: https://dmtn-208.lsst.io/
@@ -117,6 +124,22 @@ The following scopes are currently in use:
     Can create and modify tokens for the same user as the token that has this scope (as opposed to ``admin:token``, which allows any operation on tokens for any user).
     This scope is automatically granted to users when they authenticate.
     It exists as a separate scope primarily so that users can choose not to grant it to user tokens that they create, so that their programmatic tokens cannot themselves create new tokens.
+
+Expected future scopes
+======================
+
+``admin:notebook``
+    Grants access to the Notebook Aspect lab controller, if implemented according to the design in SQR-066_.
+    This must exist as a separate scope so that it can be granted to the JupyterHub service.
+
+``write:tap``
+    Write access to personal and group database tables accessible by the TAP service.
+
+It's not yet clear whether the anticipated client/server Butler service (see DMTN-176_, DMTN-169_, and DMTN-182_) will need a separate scope or will reuse one of the existing scopes plus the ``write:tap`` scope.
+
+.. _DMTN-169: https://dmtn-169.lsst.io/
+.. _DMTN-176: https://dmtn-176.lsst.io/
+.. _DMTN-182: https://dmtn-182.lsst.io/
 
 Creating new scopes
 ===================
@@ -132,7 +155,7 @@ Specifically,
 #. there exist two users who should receive different levels of access to the same deployment in a way that cannot be represented by the existing scopes, and
 #. this access control difference must be done with scopes and not groups.
 
-As discussed in :ref:`Purpose <purpose>` above, scopes control access to a service in its entirety, or to the administrative API as opposed to the user API of the service.
+As discussed in :ref:`purpose`, scopes control access to a service in its entirety, or to the administrative API as opposed to the user API of the service.
 Groups are used for all other access control.
 Groups must be interpreted by each service (or by another service to which the first service delegates access control decisions).
 Scopes are enforced by the authentication layer, before the service ever sees the request, since they determine access to the service in the first place.


### PR DESCRIPTION
Fix a reference in read:image to possibly using scopes by data release, since we're definitely not doing that.  Fix the ordering of the scopes.  Add expected future scopes and some notes about how we may change some of the scopes going forward.

Go back to using the ref tag without overriding the title, since we're not using section numbers (which is what made that look weird).