### PR TITLE
DM-43444: Add a new write:files scope

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -107,6 +107,11 @@ The following scopes are currently in use:
 ``read:tap``
     Grants access to perform queries in the TAP service.
 
+``write:files``
+    Grants write access to a user's file space.
+    Currently, this is used to control access to the user's WebDAV service.
+    This does not grant access to other user's files, only to the ones owned by the authenticated user.
+
 ``write:sasquatch``
     Grants access to write metrics to the Sasquatch telemetry service (see :sqr:`067`).
     This scope is separate so that it can be granted to service tokens for automated processes (often outside of the Science Platform) that need to record metrics.

--- a/technote.toml
+++ b/technote.toml
@@ -5,7 +5,7 @@ canonical_url = "https://dmtn-235.lsst.io/"
 github_url = "https://github.com/lsst-dm/dmtn-235"
 github_default_branch = "main"
 date_created = 2022-07-12
-date_updated = 2024-01-31
+date_updated = 2024-03-26
 organization.name = "Vera C. Rubin Observatory"
 organization.ror = "https://ror.org/048g3cy84"
 license.id = "CC-BY-4.0"
@@ -18,3 +18,6 @@ internal_id = "allberyr"
 name = "Rubin Observatory Project Office"
 internal_id = "RubinObs"
 address = "950 N. Cherry Ave., Tucson, AZ 85719, USA"
+
+[technote.status]
+state = "stable"


### PR DESCRIPTION
This will be used to control access to the user's WebDAV server. It must be a separate scope so that it can be delegated to the Portal.